### PR TITLE
Necessary changes for the option to abort from the UI

### DIFF
--- a/templates/includes/action_queue_modal.html
+++ b/templates/includes/action_queue_modal.html
@@ -1,0 +1,31 @@
+<!--
+    This template includes actions to do with the rqueues
+    Supports: Abort
+-->
+<div aria-hidden="true" aria-labelledby="myModalLabel" role="dialog" tabindex="-1" id="Abort-Rqueue-{{ rqueue.id }}" class="modal fade">
+   <div class="modal-dialog">
+      <div class="modal-content">
+         <div class="modal-header">
+            <button aria-hidden="true" data-dismiss="modal" class="close" type="button">×</button>
+            <h4 class="modal-title">
+                <b>Are you sure to abort {{ rqueue.id }} ?</b>
+            </h4>
+         </div>
+         <div class="modal-body" style="">
+            <h5>By clicking Confirm Abort, this queue will be in ABORTED state.</h5>
+            <form class="form-inline" role="form" method="POST">
+                {% csrf_token %}
+                <br>
+                <br>
+                <br>
+                <input type="hidden" id='rqueue_id' name="rqueue_id" value="{{ rqueue.id }}"/>
+                <input type="hidden" id='action' name="action" value="aborted"/>
+                <button type="submit" class="btn btn-success">
+                   <i style="margin-right: 5px"></i>
+                   <b>Confirm Abort</b>
+                </button>
+            </form>
+         </div>
+      </div>
+   </div>
+</div>

--- a/templates/includes/change_priority_modals.html
+++ b/templates/includes/change_priority_modals.html
@@ -14,10 +14,11 @@
             </h5>
             <form class="form-inline" role="form" method="POST">
                {% csrf_token %}
-               <input type="hidden" id='id' name="id" value="{{ rqueue.id }}"/>
-               <input type="hidden" id='priority' name="priority" value="{{ i }}"/>
+               <input type="hidden" id="action" name="action" value="change_priority">
+               <input type="hidden" id='rqueue_id' name="rqueue_id" value="{{ rqueue.id }}"/>
+               <input type="hidden" id='priority_value' name="priority_value" value="{{ i }}"/>
 
-                <button type="submit" class="btn btn-large btn-danger">
+               <button type="submit" class="btn btn-large btn-danger">
                    <i style="margin-right: 5px"  class="arrow_up"></i>
                    Confirm Change of Priority to <b>{{ i }}</b>
                </button>

--- a/templates/includes/pending_requests_table.html
+++ b/templates/includes/pending_requests_table.html
@@ -53,7 +53,9 @@
                     <!-- Row Options Start -->
                     <td>
                         {% include 'includes/display_json_data_modal.html' %}
-                        {% include 'includes/action_queue_modal.html' %}
+                        {% if user.is_staff %}
+                            {% include 'includes/action_queue_modal.html' %}
+                        {% endif %}
 
                         <div class="btn-group">
                             <a class="btn btn-info" href="{% url 'rqueue_more_info' slug=rqueue.id %}">
@@ -67,11 +69,13 @@
                                         Show JSON
                                     </a>
                                 </li>
-                                <li>
-                                    <a data-toggle="modal" href="#Abort-Rqueue-{{ rqueue.id }}" title="Click to abort this queue">
-                                        Abort Queue
-                                    </a>
-                                </li>
+                                {% if user.is_staff %}
+                                    <li>
+                                        <a data-toggle="modal" href="#Abort-Rqueue-{{ rqueue.id }}" title="Click to abort this queue">
+                                            Abort Queue
+                                        </a>
+                                    </li>
+                                {% endif %}
                             </ul>
                         </div>
                     </td>

--- a/templates/includes/pending_requests_table.html
+++ b/templates/includes/pending_requests_table.html
@@ -50,8 +50,11 @@
                             {{ rqueue.priority }}
                         {% endif %}
                     </td>
+                    <!-- Row Options Start -->
                     <td>
                         {% include 'includes/display_json_data_modal.html' %}
+                        {% include 'includes/action_queue_modal.html' %}
+
                         <div class="btn-group">
                             <a class="btn btn-info" href="{% url 'rqueue_more_info' slug=rqueue.id %}">
                                 <i class="icon_pencil"></i>
@@ -64,9 +67,15 @@
                                         Show JSON
                                     </a>
                                 </li>
+                                <li>
+                                    <a data-toggle="modal" href="#Abort-Rqueue-{{ rqueue.id }}" title="Click to abort this queue">
+                                        Abort Queue
+                                    </a>
+                                </li>
                             </ul>
                         </div>
                     </td>
+                    <!-- Row Options End -->
                     <!-- Row Description Start -->
                     <td>
                         <a data-original-title="Description for Rqueue with ID {{ rqueue.id }}"


### PR DESCRIPTION
This code addition will use an additional HTML template for a form to complete the process of aborting the queue from the UI.
This is only available for staff users.
Adding some pictures of how this is going to work in action

![1queue](https://user-images.githubusercontent.com/49904449/136415630-06f48f51-cc98-4f66-acfe-397b04ffb328.png)
![2queue](https://user-images.githubusercontent.com/49904449/136415646-2a5544e9-8cd7-4b6b-9d7e-76653fe17a43.png)
![3queue](https://user-images.githubusercontent.com/49904449/136415655-095cc8ef-972e-4ad7-adaa-a76a8ca759be.png)

