### PR TITLE
Add Sign Off Name/Label columns to pending and finished requests tables

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -125,7 +125,7 @@
                {% endif %}
                <!-- End display queued requests if there are any -->
                <div class="row">
-                  <div class="col-lg-12">
+                  <div class="col-lg-7">
                      <h3 class="page-header"><i class="fa fa fa-bars"></i>
                         {% block pageheader_title %}
                             Page Header Title
@@ -137,6 +137,8 @@
                         {% endblock %}
                      </ol>
                   </div>
+                  {% block messages_area %}
+                  {% endblock %}
                </div>
                <!-- page start-->
                {% block content %}

--- a/templates/includes/finished_requests_table.html
+++ b/templates/includes/finished_requests_table.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-lg-9 justify-content-center">
+  <div class="col-lg-12 justify-content-center">
     <section class="panel">
       <header class="panel-heading">
        Finished Requests
@@ -14,6 +14,12 @@
             <th style="text-align: center"><i class="icon_datareport"></i> Options</th>
             <th style="text-align: center">
                 <i class="icon_document"></i> Description
+            </th>
+            <th style="text-align: center">
+                <i class="icon_pencil"></i> Name / Label
+            </th>
+            <th style="text-align: center">
+                <i class="icon_pens"></i> Sign Off
             </th>
             <th style="text-align: center">
                 <i class="icon_search"></i> Status
@@ -59,6 +65,24 @@
                         </a>
                     </td>
                     <!-- Row Description End -->
+                    <!-- Row Label Start -->
+                    <td>
+                        {{ finishedqueue.data.name }}
+                        {{ finishedqueue.data.label }}
+                        <!--{{ finishedqueue.data.labels_string }}-->
+                    </td>
+                    <!-- Row Label End -->
+                    <!-- Row Signoff Start -->
+                    <td>
+                        {% if finishedqueue.data.link and finishedqueue.data.link != "None" %}
+                            <a href="{{ finishedqueue.data.link }}">
+                                {{ finishedqueue.data.signoff }}
+                            </a>
+                        {% else %}
+                            {{ finishedqueue.data.signoff }}
+                        {% endif %}
+                    </td>
+                    <!-- Row Signoff End -->
                     <td>
                         {{ finishedqueue.status }}
                     </td>
@@ -95,8 +119,5 @@
       </div>
       <!-- Pagination End -->
     </section>
-  </div>
-  <div id="messages-area" class="col-lg-3">
-
   </div>
 </div>

--- a/templates/includes/pending_requests_table.html
+++ b/templates/includes/pending_requests_table.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-lg-9 justify-content-center">
+  <div class="col-lg-12 justify-content-center">
     <section class="panel">
       <header class="panel-heading">
         Pending Requests All Priorities
@@ -14,6 +14,12 @@
             <th style="text-align: center"><i class="icon_datareport"></i> Options</th>
             <th style="text-align: center">
                 <i class="icon_document"></i> Description
+            </th>
+            <th style="text-align: center">
+                <i class="icon_pencil"></i> Name / Label
+            </th>
+            <th style="text-align: center">
+                <i class="icon_pens"></i> Sign Off
             </th>
             <th style="text-align: center">
                 <i class="icon_search"></i> Status
@@ -91,6 +97,24 @@
                         </a>
                     </td>
                     <!-- Row Description End -->
+                    <!-- Row Label Start -->
+                    <td>
+                        {{ rqueue.data.name }}
+                        {{ rqueue.data.label }}
+                        <!--{{ rqueue.data.labels_string }}-->
+                    </td>
+                    <!-- Row Label End -->
+                    <!-- Row Signoff Start -->
+                    <td>
+                        {% if rqueue.data.link and rqueue.data.link != "None" %}
+                            <a href="{{ rqueue.data.link }}">
+                                {{ rqueue.data.signoff }}
+                            </a>
+                        {% else %}
+                            {{ rqueue.data.signoff }}
+                        {% endif %}
+                    </td>
+                    <!-- Row Signoff End -->
                     <td>
                         {{ rqueue.status }}
                     </td>
@@ -114,9 +138,6 @@
         </tbody>
       </table>
     </section>
-  </div>
-  <div id="messages-area" class="col-lg-3">
-
   </div>
 </div>
 

--- a/templates/rqueue/finished_requests.html
+++ b/templates/rqueue/finished_requests.html
@@ -12,6 +12,11 @@
     Finished Requests
 {% endblock %}
 
+{% block messages_area %}
+    <div id="messages-area" class="col-lg-5">
+    </div>
+{% endblock %}
+
 {% block content %}
     {% include 'includes/finished_requests_table.html' %}
 {% endblock %}

--- a/templates/rqueue/pending_requests.html
+++ b/templates/rqueue/pending_requests.html
@@ -12,6 +12,11 @@
     Pending Requests
 {% endblock %}
 
+{% block messages_area %}
+    <div id="messages-area" class="col-lg-5">
+    </div>
+{% endblock %}
+
 {% block content %}
     {% if pending_requests_amount > 0 %}
         {% include 'includes/pending_requests_table.html' %}


### PR DESCRIPTION
The intention of this PR is to add _Sign Off_ and _Name/Label_ columns into the Pending Requests and Finished Requests tables:

![obrazek](https://github.com/red-hat-storage/rlocker/assets/4759779/622e5fcb-9ab9-4a03-9f11-837fd915f122)

![obrazek](https://github.com/red-hat-storage/rlocker/assets/4759779/c7373d0b-c38c-483f-9cd5-252d0c424a3d)
