### PR TITLE
3) Add batch action to release selected resources in admin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,13 @@ COPY . /code/
 #Give permissions for the code dir, to write logs
 RUN chgrp -R 0 /code && \
     chmod -R g=u /code
-CMD python manage.py check && python manage.py prepare_installed_addons && python manage.py runserver 0.0.0.0:8000
+CMD python manage.py check && \
+    python manage.py prepare_installed_addons && \
+    gunicorn rlocker.wsgi:application \
+    --bind 0.0.0.0:8000 \
+    --workers 4 \
+    --worker-class sync \
+    --timeout 600 \
+    --max-requests 1000 \
+    --max-requests-jitter 50 \
+    --log-level info

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ CMD python manage.py check && \
     python manage.py prepare_installed_addons && \
     gunicorn rlocker.wsgi:application \
     --bind 0.0.0.0:8000 \
-    --workers 4 \
+    --workers 3 \
     --worker-class sync \
     --timeout 600 \
     --max-requests 1000 \
     --max-requests-jitter 50 \
+    --worker-connections 1000 \
     --log-level info

--- a/lockable_resource/admin.py
+++ b/lockable_resource/admin.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from django.contrib.admin import ModelAdmin
 from django.db.models import Field
 from lockable_resource.models import *
+from lockable_resource.exceptions import AlreadyFreeException
 
 
 @admin.register(LockableResource)
@@ -22,7 +23,7 @@ class LockableResourceAdmin(ModelAdmin):
     search_fields = ["name", "provider", "labels_string", "signoff"]
 
     # Register admin actions
-    actions = ["enter_maintenance_mode", "exit_maintenance_mode"]
+    actions = ["enter_maintenance_mode", "exit_maintenance_mode", "release_resources"]
 
     @admin.action(description="Move selected resources to maintenance mode")
     def enter_maintenance_mode(self, request, queryset):
@@ -49,3 +50,52 @@ class LockableResourceAdmin(ModelAdmin):
             f"{updated_count} resource(s) successfully exited from maintenance mode.",
             level="SUCCESS",
         )
+
+    @admin.action(description="Release selected resources")
+    def release_resources(self, request, queryset):
+        """
+        Admin action to release selected locked resources.
+        Calls the release() method on each resource to properly clean up
+        signoff and associated queue.
+        """
+        released_count = 0
+        already_free_count = 0
+        error_count = 0
+
+        for resource in queryset:
+            try:
+                resource.release()
+                released_count += 1
+            except AlreadyFreeException:
+                already_free_count += 1
+            except Exception as e:
+                error_count += 1
+                self.message_user(
+                    request,
+                    f"Error releasing resource '{resource.name}': {str(e)}",
+                    level="ERROR",
+                )
+
+        # Show success message for released resources
+        if released_count > 0:
+            self.message_user(
+                request,
+                f"{released_count} resource(s) successfully released.",
+                level="SUCCESS",
+            )
+
+        # Show info message for already free resources
+        if already_free_count > 0:
+            self.message_user(
+                request,
+                f"{already_free_count} resource(s) were already free.",
+                level="INFO",
+            )
+
+        # Show warning if there were errors
+        if error_count > 0:
+            self.message_user(
+                request,
+                f"{error_count} resource(s) failed to release. See errors above.",
+                level="WARNING",
+            )

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -8,9 +8,9 @@ server {
         proxy_pass ${NGINX_PROXY_PASS};
 
         # Timeout configuration to match Django REQUEST_TIMEOUT (600s)
-        proxy_connect_timeout 10s;
+        proxy_connect_timeout 60s;
         proxy_read_timeout 600s;
-        proxy_send_timeout 30s;
+        proxy_send_timeout 60s;
 
         # Performance optimizations
         proxy_buffering off;

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ django-extensions==4.1
 django-filter==25.2
 djangorestframework==3.16.1
 Markdown==3.10.2
+gunicorn==21.2.0
 psycopg2-binary==2.9.11
 pytz==2026.1.post1
 PyYAML==6.0.3

--- a/rlocker/settings.py
+++ b/rlocker/settings.py
@@ -107,6 +107,7 @@ PROD_DB = {
         "PASSWORD": os.environ.get("POSTGRESQL_PASSWORD"),
         "HOST": os.environ.get("DATABASE_SERVICE_NAME"),
         "CONN_MAX_AGE": 600,  # Reuse connections for 10 minutes
+        "CONN_HEALTH_CHECKS": True,  # Verify connections are alive before use
         "OPTIONS": {
             "connect_timeout": 10,
             "options": "-c statement_timeout=30000"  # 30 second statement timeout

--- a/rlocker/settings.py
+++ b/rlocker/settings.py
@@ -106,6 +106,11 @@ PROD_DB = {
         "USER": os.environ.get("POSTGRESQL_USER"),
         "PASSWORD": os.environ.get("POSTGRESQL_PASSWORD"),
         "HOST": os.environ.get("DATABASE_SERVICE_NAME"),
+        "CONN_MAX_AGE": 600,  # Reuse connections for 10 minutes
+        "OPTIONS": {
+            "connect_timeout": 10,
+            "options": "-c statement_timeout=30000"  # 30 second statement timeout
+        }
     }
 }
 

--- a/rqueue/signals.py
+++ b/rqueue/signals.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from rqueue.models import Rqueue
@@ -8,6 +9,7 @@ from urllib.parse import unquote
 
 
 @receiver(post_save, sender=Rqueue)
+@transaction.atomic
 def fetch_for_available_lockable_resources(sender, instance, created, **kwargs):
     """
     The logic to add requests to queue is with the following convention:
@@ -56,6 +58,7 @@ def fetch_for_available_lockable_resources(sender, instance, created, **kwargs):
 
 
 @receiver(pre_save, sender=Rqueue)
+@transaction.atomic
 def execute_pre_save_actions_for_rqueue(sender, instance, **kwargs):
     """
     For any changes prior saving a Rqueue obj, do it here!

--- a/rqueue/signals.py
+++ b/rqueue/signals.py
@@ -34,7 +34,7 @@ def fetch_for_available_lockable_resources(sender, instance, created, **kwargs):
         data_signoff = data.get("signoff")
 
         if instance.priority == Priority.UI.value:
-            lock_res_object = LockableResource.objects.get(id=data_id)
+            lock_res_object = LockableResource.objects.select_for_update().get(id=data_id)
             lock_res_object.lock(signoff=data_signoff)
             lock_res_object.associated_queue = instance
             lock_res_object.save()
@@ -102,7 +102,7 @@ def execute_pre_save_actions_for_rqueue(sender, instance, **kwargs):
             )
             if final_resource:
                 # Get the resource object:
-                final_resource_obj = LockableResource.objects.get(name=final_resource)
+                final_resource_obj = LockableResource.objects.select_for_update().get(name=final_resource)
                 final_resource_obj.associated_queue = instance
                 final_resource_obj.save()
 


### PR DESCRIPTION
Implements a new admin action that allows administrators to release multiple locked resources at once from the Django admin interface. The action properly calls the release() method on each resource to clear signoff and associated queue, and provides detailed feedback about successfully released, already free, and failed resources.
This is useful mainly for testing environments.
