### PR TITLE
add admin commands to export and import user accounts

### DIFF
--- a/account/README.md
+++ b/account/README.md
@@ -1,0 +1,125 @@
+# Account App
+
+This Django app handles user account management and authentication for rlocker.
+
+## Features
+
+- Automatic API token generation for new users (via Django signals)
+- User account creation and management
+- Integration with Django REST Framework token authentication
+
+## Management Commands
+
+### create_accounts
+Interactive command for creating multiple user accounts at once.
+
+**Usage:**
+```bash
+python manage.py create_accounts
+```
+
+This will prompt for:
+- List of usernames (comma-separated)
+- Initial password for all users
+- Groups to add users to
+
+### retrieve_token
+Get the API token for a specific user.
+
+**Usage:**
+```bash
+python manage.py retrieve_token -u USERNAME
+```
+
+**Example:**
+```bash
+python manage.py retrieve_token -u alice
+# Output: a1b2c3d4e5f6...
+```
+
+### export_users
+Export users, groups, and API tokens to a JSON file for migration.
+
+**Usage:**
+```bash
+python manage.py export_users [-o OUTPUT_FILE] [--pretty]
+```
+
+**Options:**
+- `-o FILE`, `--output FILE` - Output file path (default: users_export.json)
+- `--pretty` - Format JSON with indentation
+
+**Example:**
+```bash
+python manage.py export_users -o backup.json --pretty
+```
+
+See [USER_MIGRATION_GUIDE.md](../USER_MIGRATION_GUIDE.md) for details.
+
+### import_users
+Import users, groups, and API tokens from a JSON file.
+
+**Usage:**
+```bash
+python manage.py import_users [-i INPUT_FILE] [OPTIONS]
+```
+
+**Options:**
+- `-i FILE`, `--input FILE` - Input file path (default: users_export.json)
+- `--skip-existing` - Skip users that already exist
+- `--dry-run` - Preview changes without making them
+- `--ignore-tokens` - Don't import API tokens
+
+**Example:**
+```bash
+# Preview import
+python manage.py import_users -i backup.json --dry-run
+
+# Actual import
+python manage.py import_users -i backup.json
+```
+
+See [USER_MIGRATION_GUIDE.md](../USER_MIGRATION_GUIDE.md) for details.
+
+## Signals
+
+### create_token_once_user_registers
+Automatically creates an API token whenever a new user is created.
+
+**Signal:** `post_save` on `User` model
+**Handler:** `account.signals.create_token_once_user_registers`
+
+This ensures every user has an API token for REST API authentication.
+
+## Authentication
+
+This app works with Django REST Framework's token authentication:
+
+```python
+# In API views
+from api.custom_permissions import HasValidTokenOrIsAuthenticated
+
+@permission_classes([HasValidTokenOrIsAuthenticated])
+def my_api_view(request):
+    # Users can authenticate via:
+    # 1. Session authentication (logged in via web)
+    # 2. Token authentication (header: Authorization: Token <key>)
+    pass
+```
+
+## Migration Helper
+
+For easy user migration between rlocker instances, use the helper script:
+
+```bash
+# Export users
+./migrate_users.sh export
+
+# Import users
+./migrate_users.sh import users_export.json
+
+# See all options
+./migrate_users.sh help
+```
+
+See [USER_MIGRATION_GUIDE.md](../USER_MIGRATION_GUIDE.md) for complete migration documentation.

--- a/account/management/commands/export_users.py
+++ b/account/management/commands/export_users.py
@@ -1,0 +1,89 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import User, Group
+from rest_framework.authtoken.models import Token
+import json
+
+
+class Command(BaseCommand):
+    help = "Export users, groups, and tokens to JSON file for migration"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            default="users_export.json",
+            help="Output JSON file path (default: users_export.json)",
+        )
+        parser.add_argument(
+            "--pretty",
+            action="store_true",
+            help="Format JSON with indentation for readability",
+        )
+
+    def handle(self, *args, **options):
+        output_file = options["output"]
+        pretty = options["pretty"]
+
+        # Export groups
+        groups_data = []
+        for group in Group.objects.all():
+            groups_data.append(
+                {
+                    "id": group.id,
+                    "name": group.name,
+                }
+            )
+
+        # Export users
+        users_data = []
+        for user in User.objects.all():
+            try:
+                token = Token.objects.get(user=user).key
+            except Token.DoesNotExist:
+                token = None
+
+            users_data.append(
+                {
+                    "id": user.id,
+                    "username": user.username,
+                    "password": user.password,  # Already hashed
+                    "email": user.email,
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
+                    "is_staff": user.is_staff,
+                    "is_superuser": user.is_superuser,
+                    "is_active": user.is_active,
+                    "date_joined": user.date_joined.isoformat(),
+                    "last_login": user.last_login.isoformat() if user.last_login else None,
+                    "token": token,
+                    "groups": [g.name for g in user.groups.all()],
+                }
+            )
+
+        # Combine all data
+        export_data = {
+            "export_metadata": {
+                "version": "1.0",
+                "exported_at": __import__("datetime").datetime.now().isoformat(),
+            },
+            "groups": groups_data,
+            "users": users_data,
+        }
+
+        # Write to file
+        with open(output_file, "w") as f:
+            if pretty:
+                json.dump(export_data, f, indent=2)
+            else:
+                json.dump(export_data, f)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\nExport complete:\n"
+                f"  File: {output_file}\n"
+                f"  Groups: {len(groups_data)}\n"
+                f"  Users: {len(users_data)}\n"
+                f"  Tokens: {sum(1 for u in users_data if u['token'])}"
+            )
+        )

--- a/account/management/commands/import_users.py
+++ b/account/management/commands/import_users.py
@@ -1,0 +1,212 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.auth.models import User, Group
+from rest_framework.authtoken.models import Token
+from django.db import transaction
+from datetime import datetime
+import json
+
+
+class Command(BaseCommand):
+    help = "Import users, groups, and tokens from JSON file for migration"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-i",
+            "--input",
+            type=str,
+            default="users_export.json",
+            help="Input JSON file path (default: users_export.json)",
+        )
+        parser.add_argument(
+            "--skip-existing",
+            action="store_true",
+            help="Skip users that already exist (default: update them)",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be imported without making changes",
+        )
+        parser.add_argument(
+            "--ignore-tokens",
+            action="store_true",
+            help="Don't import tokens (new tokens will be auto-generated)",
+        )
+
+    def handle(self, *args, **options):
+        input_file = options["input"]
+        skip_existing = options["skip_existing"]
+        dry_run = options["dry_run"]
+        ignore_tokens = options["ignore_tokens"]
+
+        # Read import file
+        try:
+            with open(input_file, "r") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            raise CommandError(f"File not found: {input_file}")
+        except json.JSONDecodeError as e:
+            raise CommandError(f"Invalid JSON file: {e}")
+
+        # Validate file structure
+        if "users" not in data:
+            raise CommandError("Invalid export file: missing 'users' key")
+        if "groups" not in data:
+            raise CommandError("Invalid export file: missing 'groups' key")
+
+        groups_data = data["groups"]
+        users_data = data["users"]
+
+        if dry_run:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"\n=== DRY RUN MODE ===\n"
+                    f"Would import:\n"
+                    f"  Groups: {len(groups_data)}\n"
+                    f"  Users: {len(users_data)}\n"
+                )
+            )
+
+        # Import with transaction
+        try:
+            with transaction.atomic():
+                # Import groups first
+                groups_created = 0
+                groups_existing = 0
+
+                for group_data in groups_data:
+                    group_name = group_data["name"]
+
+                    if dry_run:
+                        if Group.objects.filter(name=group_name).exists():
+                            groups_existing += 1
+                        else:
+                            groups_created += 1
+                        continue
+
+                    group, created = Group.objects.get_or_create(name=group_name)
+                    if created:
+                        groups_created += 1
+                        self.stdout.write(f"  Created group: {group_name}")
+                    else:
+                        groups_existing += 1
+
+                # Import users
+                users_created = 0
+                users_updated = 0
+                users_skipped = 0
+                tokens_created = 0
+                tokens_updated = 0
+
+                for user_data in users_data:
+                    username = user_data["username"]
+
+                    try:
+                        user = User.objects.get(username=username)
+
+                        if skip_existing:
+                            users_skipped += 1
+                            if not dry_run:
+                                self.stdout.write(f"  Skipped existing: {username}")
+                            continue
+
+                        # Update existing user
+                        if not dry_run:
+                            user.password = user_data["password"]
+                            user.email = user_data["email"]
+                            user.first_name = user_data["first_name"]
+                            user.last_name = user_data["last_name"]
+                            user.is_staff = user_data["is_staff"]
+                            user.is_superuser = user_data["is_superuser"]
+                            user.is_active = user_data["is_active"]
+
+                            if user_data["last_login"]:
+                                user.last_login = datetime.fromisoformat(
+                                    user_data["last_login"]
+                                )
+
+                            user.save()
+                            self.stdout.write(f"  Updated user: {username}")
+
+                        users_updated += 1
+
+                    except User.DoesNotExist:
+                        # Create new user
+                        if not dry_run:
+                            user = User(
+                                username=username,
+                                password=user_data["password"],  # Already hashed
+                                email=user_data["email"],
+                                first_name=user_data["first_name"],
+                                last_name=user_data["last_name"],
+                                is_staff=user_data["is_staff"],
+                                is_superuser=user_data["is_superuser"],
+                                is_active=user_data["is_active"],
+                                date_joined=datetime.fromisoformat(
+                                    user_data["date_joined"]
+                                ),
+                            )
+
+                            if user_data["last_login"]:
+                                user.last_login = datetime.fromisoformat(
+                                    user_data["last_login"]
+                                )
+
+                            user.save()
+                            self.stdout.write(
+                                self.style.SUCCESS(f"  Created user: {username}")
+                            )
+
+                        users_created += 1
+
+                    # Handle groups
+                    if not dry_run:
+                        user.groups.clear()
+                        for group_name in user_data["groups"]:
+                            try:
+                                group = Group.objects.get(name=group_name)
+                                user.groups.add(group)
+                            except Group.DoesNotExist:
+                                self.stdout.write(
+                                    self.style.WARNING(
+                                        f"    Group not found: {group_name}, skipping"
+                                    )
+                                )
+
+                    # Handle token
+                    if not ignore_tokens and user_data["token"]:
+                        if not dry_run:
+                            token, created = Token.objects.update_or_create(
+                                user=user, defaults={"key": user_data["token"]}
+                            )
+
+                            if created:
+                                tokens_created += 1
+                            else:
+                                tokens_updated += 1
+
+                # If dry run, rollback transaction
+                if dry_run:
+                    transaction.set_rollback(True)
+
+        except Exception as e:
+            raise CommandError(f"Import failed: {e}")
+
+        # Summary
+        summary = (
+            f"\n{'DRY RUN - ' if dry_run else ''}Import complete:\n"
+            f"  Groups: {groups_created} created, {groups_existing} already existed\n"
+            f"  Users: {users_created} created, {users_updated} updated, {users_skipped} skipped\n"
+        )
+
+        if not ignore_tokens:
+            summary += (
+                f"  Tokens: {tokens_created} created, {tokens_updated} updated\n"
+            )
+        else:
+            summary += f"  Tokens: skipped (will be auto-generated on first save)\n"
+
+        if dry_run:
+            summary += "\nNo changes were made (dry run mode)\n"
+
+        self.stdout.write(self.style.SUCCESS(summary))

--- a/migrate_users.sh
+++ b/migrate_users.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# User Migration Helper Script for rlocker
+# This script provides a convenient interface for exporting and importing users
+
+set -e  # Exit on error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_PATH="${SCRIPT_DIR}/venv"
+MANAGE_PY="${SCRIPT_DIR}/manage.py"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Functions
+print_header() {
+    echo -e "${BLUE}======================================${NC}"
+    echo -e "${BLUE}  rlocker User Migration Tool${NC}"
+    echo -e "${BLUE}======================================${NC}"
+    echo
+}
+
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+print_warning() {
+    echo -e "${YELLOW}⚠ $1${NC}"
+}
+
+print_info() {
+    echo -e "${BLUE}ℹ $1${NC}"
+}
+
+activate_venv() {
+    if [ ! -d "$VENV_PATH" ]; then
+        print_error "Virtual environment not found at: $VENV_PATH"
+        print_info "Please create it first: python -m venv venv"
+        exit 1
+    fi
+
+    source "$VENV_PATH/bin/activate"
+    print_success "Virtual environment activated"
+}
+
+check_dependencies() {
+    if ! command -v python &> /dev/null; then
+        print_error "Python not found"
+        exit 1
+    fi
+
+    if [ ! -f "$MANAGE_PY" ]; then
+        print_error "manage.py not found at: $MANAGE_PY"
+        exit 1
+    fi
+}
+
+show_usage() {
+    cat << EOF
+Usage: $0 [COMMAND] [OPTIONS]
+
+Commands:
+  export [FILE]           Export users to JSON file
+                          Default file: users_export.json
+
+  import [FILE]           Import users from JSON file
+                          Default file: users_export.json
+
+  preview [FILE]          Preview what would be imported (dry-run)
+
+  backup [FILE]           Create timestamped backup
+                          Default file: users_backup_YYYY-MM-DD_HH-MM-SS.json
+
+  merge [FILE]            Import users but skip existing ones
+                          Useful for merging two user databases
+
+  status                  Show user/group statistics
+
+  help                    Show this help message
+
+Examples:
+  $0 export                          # Export to users_export.json
+  $0 export my_users.json            # Export to specific file
+  $0 backup                          # Create timestamped backup
+  $0 preview users_backup.json       # Preview import
+  $0 import users_backup.json        # Import users
+  $0 merge other_users.json          # Merge without overwriting
+
+Options:
+  You can also pass additional Django management command options:
+  $0 export --pretty                 # Pretty-print JSON
+  $0 import --ignore-tokens          # Don't import API tokens
+
+EOF
+}
+
+export_users() {
+    local output_file="${1:-users_export.json}"
+
+    print_info "Exporting users to: $output_file"
+
+    python "$MANAGE_PY" export_users -o "$output_file" --pretty
+
+    if [ -f "$output_file" ]; then
+        local size=$(du -h "$output_file" | cut -f1)
+        print_success "Export complete: $output_file ($size)"
+        print_warning "Secure this file - it contains password hashes and tokens!"
+        echo
+        print_info "To transfer to another server:"
+        echo "  scp $output_file user@server:/path/to/rlocker/"
+    else
+        print_error "Export failed - file not created"
+        exit 1
+    fi
+}
+
+import_users() {
+    local input_file="${1:-users_export.json}"
+
+    if [ ! -f "$input_file" ]; then
+        print_error "File not found: $input_file"
+        exit 1
+    fi
+
+    print_warning "This will modify the database!"
+    print_info "Importing from: $input_file"
+    echo
+
+    read -p "Continue with import? [y/N] " -n 1 -r
+    echo
+
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_info "Import cancelled"
+        exit 0
+    fi
+
+    python "$MANAGE_PY" import_users -i "$input_file"
+
+    print_success "Import complete!"
+}
+
+preview_import() {
+    local input_file="${1:-users_export.json}"
+
+    if [ ! -f "$input_file" ]; then
+        print_error "File not found: $input_file"
+        exit 1
+    fi
+
+    print_info "Previewing import from: $input_file"
+    print_info "No changes will be made"
+    echo
+
+    python "$MANAGE_PY" import_users -i "$input_file" --dry-run
+}
+
+backup_users() {
+    local timestamp=$(date +%Y-%m-%d_%H-%M-%S)
+    local output_file="${1:-users_backup_${timestamp}.json}"
+
+    print_info "Creating backup: $output_file"
+
+    export_users "$output_file"
+}
+
+merge_users() {
+    local input_file="${1:-users_export.json}"
+
+    if [ ! -f "$input_file" ]; then
+        print_error "File not found: $input_file"
+        exit 1
+    fi
+
+    print_info "Merging users from: $input_file"
+    print_info "Existing users will be skipped (not updated)"
+    echo
+
+    read -p "Continue with merge? [y/N] " -n 1 -r
+    echo
+
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        print_info "Merge cancelled"
+        exit 0
+    fi
+
+    python "$MANAGE_PY" import_users -i "$input_file" --skip-existing
+
+    print_success "Merge complete!"
+}
+
+show_status() {
+    print_info "Database Statistics"
+    echo
+
+    python "$MANAGE_PY" shell << 'EOF'
+from django.contrib.auth.models import User, Group
+from rest_framework.authtoken.models import Token
+
+total_users = User.objects.count()
+active_users = User.objects.filter(is_active=True).count()
+staff_users = User.objects.filter(is_staff=True).count()
+superusers = User.objects.filter(is_superuser=True).count()
+total_groups = Group.objects.count()
+total_tokens = Token.objects.count()
+
+print(f"Users:")
+print(f"  Total:      {total_users}")
+print(f"  Active:     {active_users}")
+print(f"  Staff:      {staff_users}")
+print(f"  Superuser:  {superusers}")
+print(f"\nGroups:       {total_groups}")
+print(f"Tokens:       {total_tokens}")
+
+if total_groups > 0:
+    print(f"\nGroup Names:")
+    for group in Group.objects.all():
+        member_count = group.user_set.count()
+        print(f"  - {group.name} ({member_count} members)")
+EOF
+
+    echo
+}
+
+# Main script
+main() {
+    print_header
+
+    check_dependencies
+    activate_venv
+
+    echo
+
+    local command="${1:-help}"
+    shift || true
+
+    case "$command" in
+        export)
+            export_users "$@"
+            ;;
+        import)
+            import_users "$@"
+            ;;
+        preview)
+            preview_import "$@"
+            ;;
+        backup)
+            backup_users "$@"
+            ;;
+        merge)
+            merge_users "$@"
+            ;;
+        status)
+            show_status
+            ;;
+        help|--help|-h)
+            show_usage
+            ;;
+        *)
+            print_error "Unknown command: $command"
+            echo
+            show_usage
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

  - Add `export_users` management command to export users, groups, and API tokens to a JSON file
  - Add `import_users` management command to import users from a JSON file with support for `--dry-run`, `--skip-existing`, and `--ignore-tokens` options
  - Add `migrate_users.sh` helper script providing a user-friendly CLI wrapper for export/import/backup/merge/preview/status operations
  - Add documentation to `account/README.md` covering all management commands

  ## Details

  **`export_users` command:**
  - Exports all users with their profile fields, hashed passwords, group memberships, and API tokens
  - Supports `--pretty` for human-readable JSON output
  - Includes export metadata (version, timestamp)

  **`import_users` command:**
  - Creates or updates users from an exported JSON file
  - `--dry-run` previews changes without modifying the database (uses transaction rollback)
  - `--skip-existing` skips users that already exist instead of updating them
  - `--ignore-tokens` skips token import (tokens auto-generate via existing signal)
  - Runs inside a database transaction for atomicity
  - Handles group assignment and token creation/update

  **`migrate_users.sh` script:**
  - Wraps the Django commands with confirmation prompts, colored output, and convenience subcommands (`export`, `import`, `preview`, `backup`, `merge`, `status`)
  - Auto-activates the virtualenv

