### PR TITLE
Fix locking resource by name ignoring maintenance status

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -20,12 +20,17 @@ class LockableResourceSerializer(serializers.ModelSerializer):
 
     def validate(self, attrs):
         """
-        Check that the Resource is not Locked
+        Check that the Resource is not Locked and not in Maintenance
         :param data:
         :return:
         """
         lr_name = attrs.get("name")
         lr_object_pre_save = LockableResource.objects.get(name=lr_name)
+        if lr_object_pre_save.in_maintenance and attrs.get("is_locked"):
+            raise exceptions.NotAcceptable(
+                detail=f"Lockable Resource [{lr_name}] is under maintenance and cannot be locked! "
+                "Please wait until maintenance is over before attempting to lock this resource. "
+            )
         if lr_object_pre_save.is_locked and attrs.get("is_locked"):
             # Important note: raises 406 code status for handling in different services
             raise exceptions.NotAcceptable(

--- a/lockable_resource/exceptions.py
+++ b/lockable_resource/exceptions.py
@@ -11,6 +11,13 @@ class AlreadyFreeException(Exception):
         print("The Lockable Resource you are trying to Release is already Free!")
 
 
+class ResourceInMaintenanceException(Exception):
+    def __init__(self, name=""):
+        print(
+            f"The Lockable Resource {name} is under maintenance and cannot be locked!"
+        )
+
+
 class FreeResourceNotAvailableException(Exception):
     def __init__(self, attempted_string):
         print(

--- a/lockable_resource/models.py
+++ b/lockable_resource/models.py
@@ -1,5 +1,9 @@
 from django.db import models
-from lockable_resource.exceptions import AlreadyFreeException, AlreadyLockedException
+from lockable_resource.exceptions import (
+    AlreadyFreeException,
+    AlreadyLockedException,
+    ResourceInMaintenanceException,
+)
 from rqueue.models import Rqueue
 from rqueue.utils import DescriptiveTime
 import lockable_resource.constants as const
@@ -207,9 +211,12 @@ class LockableResource(models.Model):
         This method will lock the resource if it is requested.
             It will assign a new signoff message.
 
+        :raises: ResourceInMaintenanceException
         :raises: AlreadyLockedException
         :returns: None
         """
+        if self.in_maintenance:
+            raise ResourceInMaintenanceException(self.name)
         if self.can_lock:
             self.is_locked = True
             self.signoff = signoff

--- a/rqueue/signals.py
+++ b/rqueue/signals.py
@@ -4,7 +4,7 @@ from django.dispatch import receiver
 from rqueue.models import Rqueue
 from rqueue.constants import Priority, Interval, Status
 from lockable_resource.models import LockableResource
-from lockable_resource.exceptions import AlreadyLockedException
+from lockable_resource.exceptions import AlreadyLockedException, ResourceInMaintenanceException
 from rqueue.utils import *
 from urllib.parse import unquote
 
@@ -58,6 +58,13 @@ def fetch_for_available_lockable_resources(sender, instance, created, **kwargs):
                 # An external service will retry when the resource becomes available
                 print(
                     f"Resource {lock_res_object.name} is already locked. "
+                    f"Queue {instance.id} remains PENDING with priority {instance.priority}"
+                )
+            except ResourceInMaintenanceException:
+                # Resource is under maintenance, leave the queue in PENDING status
+                # An external service will retry when maintenance is over
+                print(
+                    f"Resource {lock_res_object.name} is under maintenance. "
                     f"Queue {instance.id} remains PENDING with priority {instance.priority}"
                 )
 


### PR DESCRIPTION
The lock() method and the Rqueue post_save signal did not check the in_maintenance flag, allowing resources under maintenance to be locked when requested by name. Add ResourceInMaintenanceException and enforce the maintenance check in lock(), the signal handler, and the serializer validate().