### PR TITLE
Fix link not being set on resource when locking via queue

### DIFF
--- a/rqueue/signals.py
+++ b/rqueue/signals.py
@@ -34,6 +34,7 @@ def fetch_for_available_lockable_resources(sender, instance, created, **kwargs):
         data_id = data.get("id")
         data_label = data.get("label")
         data_signoff = data.get("signoff")
+        data_link = data.get("link")
 
         # Differentiate based on data structure, not just priority:
         # - If data has "id": we know the exact resource to lock (UI or search_by_name)
@@ -46,6 +47,8 @@ def fetch_for_available_lockable_resources(sender, instance, created, **kwargs):
             try:
                 lock_res_object.lock(signoff=data_signoff)
                 lock_res_object.associated_queue = instance
+                if data_link and data_link != "None":
+                    lock_res_object.link = data_link
                 lock_res_object.save()
                 instance.add_to_data_json(json_to_add=lock_res_object.json_parse())
                 instance.report_finish()


### PR DESCRIPTION
The queue-based locking path (find_resource → retrieve_resource_by_name → Rqueue signal) stored the link in the queue data but never extracted and set it on the LockableResource. This caused resources locked via the queue to lose their job link while direct API locks preserved it.